### PR TITLE
Fix compilation on Windows 64-bit

### DIFF
--- a/pascal/jsonstream.pas
+++ b/pascal/jsonstream.pas
@@ -429,7 +429,7 @@ implementation
 uses
   math
   {$ifdef FPC}
-  {$ifndef WIN32}
+  {$ifndef MSWINDOWS}
   , cwstring
   {$endif}
   {$endif}


### PR DESCRIPTION
Check for `  {$ifndef MSWINDOWS}` not `  {$ifndef WIN32}`. This avoids trying to use (non-existent) `cwstring` unit on 64-bit Windows, which was making compilation fail. Tested with FPC 3.2.2.